### PR TITLE
feat: Check group owner partner status before adding to session

### DIFF
--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { GameGateway } from './game.gateway';
+import { RevshareModule } from 'src/revshare/revshare.module';
 
-@Module({})
+@Module({
+  imports: [RevshareModule],
+  providers: [GameGateway],
+})
 export class GameModule {}


### PR DESCRIPTION
I've modified the 'start' game gateway (`handleStart` method in `GameGateway`) to verify if a group owner is an approved partner in the revenue share system before adding them to the game session's `groupOwners` list.

This involved:
- Injecting `RevshareService` into `GameGateway`.
- Calling `revshareService.findRequestByTelegramUserId` for each potential group owner (from `player1.groupOwner` and `player2.groupOwner`).
- Adding the owner to the `sessionData.groupOwners` array only if a corresponding revshare request exists and its status is 'approved'.
- I also added comprehensive unit tests in `game.gateway.spec.ts` to cover various scenarios:
    - Owner approved
    - Owner pending/rejected
    - Owner not found
    - Combinations of statuses for two owners
    - No owners present
    - Error during revshare check

This change ensures that only active and approved revenue share partners are included for potential bonus distributions during gameplay.